### PR TITLE
Fix index offset off-by-one error

### DIFF
--- a/node_tabber/operators.py
+++ b/node_tabber/operators.py
@@ -168,7 +168,7 @@ class NODE_OT_add_tabber_search(bpy.types.Operator):
                         str(tally),
                         index_offset+1+index2,
                     ))
-                index_offset += index2
+                index_offset += index2+1
 
             if vector_math_index > -1:
                 nt_debug("Adding vector math nodes")
@@ -182,7 +182,7 @@ class NODE_OT_add_tabber_search(bpy.types.Operator):
                         str(tally),
                         index_offset+1+index2,
                     ))
-                index_offset += index2
+                index_offset += index2+1
 
             if mix_rgb_index > -1:
                 nt_debug("Adding mix rgb nodes")
@@ -196,7 +196,7 @@ class NODE_OT_add_tabber_search(bpy.types.Operator):
                         str(tally),
                         index_offset+1+index2,
                     ))
-                index_offset += index2
+                index_offset += index2+1
 
 
 


### PR DESCRIPTION
This fixes https://github.com/jiggymoon69/node_tabber/issues/3

It also fixes adding whichever mix rgb sub-node happened to be listed first. In my case that meant adding the COLOR sub-node would result in getting a vector math tangent instead.